### PR TITLE
losen restrictions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-    Scipy==1.14.1
-    numpy==2.1.2
-    mne==1.8.0
+    Scipy>=1.14.1
+    numpy>=2.1.2
+    mne>=1.8.0
     Flask==3.0.3
     peewee==3.17.6
     pylsl==1.16.2
     usleep_api==0.1.3
     setuptools==70.3.0
-    edfio==0.4.3
+    edfio>=0.4.3


### PR DESCRIPTION
Are the version restrictions fix?

Maybe it would be possible to losen the version numbers and assume forward compatibility? This way we could install napview more easily in existing envs without interfering with existing versions

Feel free to discard if you disagree or to even remove version numbering completely for e.,g. `numpy` (usually quite robust to changes)